### PR TITLE
Standardize contrib guidelines across public repos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+See the page titled "[Ways to Contribute](https://docs.oceanprotocol.com/concepts/contributing/)" in the Ocean Protocol documentation.

--- a/README.md
+++ b/README.md
@@ -45,11 +45,7 @@ You can sail the Ocean with Nautilina in your pocket as a provider or a consumer
 
 ### Contributing
 
-We use GitHub as a means for maintaining and tracking issues and source code development.
-
-If you would like to contribute, please fork this repository, do work in a feature branch, and finally open a pull request for maintainers to review your changes.
-
-Ocean Protocol uses [C4 Standard process](https://github.com/unprotocols/rfc/blob/master/1/README.md) to manage changes in the source code.  Find here more details about [Ocean C4 OEP](https://github.com/oceanprotocol/OEPs/tree/master/1).
+See the page titled "[Ways to Contribute](https://docs.oceanprotocol.com/concepts/contributing/)" in the Ocean Protocol documentation.
 
 ### License
 


### PR DESCRIPTION
We're standardizing the Ocean Protocol contribution guidelines across all public repos by linking to one standard central page in the docs. It's easier to update one page than 30+ pages. (We currently have 36 public repos.)